### PR TITLE
Correct broken-notice

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -59,8 +59,6 @@ Writing plugins with PythonLoader is fairly easy. There are two APIs, both
 of which are pretty simple; The first is the bukkit api, which this loader
 lightly wraps; and the other is a decorators-and-functions api.
 
-**Note: The decorator API is [broken at the moment](https://github.com/gdude2002/Python-Plugin-Loader/issues/1).**
-
 Basics
 ------
 
@@ -78,6 +76,8 @@ And so on.
 
 Class (standard Bukkit API
 ---------------------------
+
+**Note: The Class API is [currently not working](https://github.com/gdude2002/Python-Plugin-Loader/issues/1#issuecomment-50282565). Use the Decorator API (below) instead!**
 
 To writing a plugin with this API is almost identical to writing one in Java - so
 much so that you can safely use the documentation on how to write a java
@@ -107,9 +107,10 @@ class SampleClass(PythonPlugin):
 Decorator API
 -------------
 
+**Note: The Decorator API has [a bug](https://github.com/gdude2002/Python-Plugin-Loader/issues/1)**
+
 Writing a plugin with this api is much more concise, as you need to declare no
-classes. **But it's [not working right now](https://github.com/gdude2002/Python-Plugin-Loader/issues/1)**,
-so use the class-based API instead.
+classes.
 
 `plugin.yml`:
 


### PR DESCRIPTION
The decorator API is not "broken", it only has a a bug which already has a [known workaround](https://github.com/intangir/AnarchicFrontiers/blob/master/plugins/Tweak_Lobby.py#L56-L57) while the class API can currently not be used at all.
