### PR TITLE
Update to jython 2.7.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,9 +40,10 @@ repositories {
         // dirs '../lib', 'lib'
         dirs 'lib'
     }
-    // Bukkit
+    // Spigot + Dependencies
     maven {
-        url 'http://repo.bukkit.org/content/groups/public/'
+        url "https://hub.spigotmc.org/nexus/content/repositories/snapshots/"
+        url "https://hub.spigotmc.org/nexus/content/repositories/public/"
     }
     // Maven central
     mavenCentral()
@@ -92,8 +93,8 @@ publishing {
 }
 
 dependencies {
-    compile 'org.python:jython-standalone:2.7-rc1'
-    compile 'org.bukkit:bukkit:1.7.9-R0.2', {
+    compile 'org.python:jython-standalone:2.7.0'
+    compile 'org.bukkit:bukkit:1.9-R0.1-SNAPSHOT', {
         ext {
             fatJarExclude = true
         }


### PR DESCRIPTION
Also builds against build against Spigot/Bukkit 1.9-R0.1 now.

Most important change in jython is probably https://github.com/jythontools/jython/commit/b8bf8cf6217c732edb2706ffb95c972255939415, which fastens the load time of JSON by orders of magnitude.

For example, we had a ~1.5MB JSON file that delayed our server startup by several minutes, now it loads in way under 1 second.

I've [uploaded a jar](https://github.com/RedstonerServer/Python-Plugin-Loader/releases/tag/v0.4.1) if anyone wants to play around with it.